### PR TITLE
Add splits for combat simulator

### DIFF
--- a/Trepang2/Trepang2.Settings.xml
+++ b/Trepang2/Trepang2.Settings.xml
@@ -30,4 +30,5 @@
         <Setting Id="Mission_SyndicateHQ_Betrayal_C__enter" Label="Betrayal in Safehouse" State="false" />
         <Setting Id="Mission_SyndicateHQFinal_C__exit"      Label="Beat the Game"         State="true" />
     </Setting>
+    <Setting Id="combat_sim_waves" Label="Start/split on combat simulator waves" State="false" />
 </Settings>


### PR DESCRIPTION
The initial implementation is based on classifying alive characters as the player, friends, and enemies. Start is triggered when the number of enemies transitions from zero to non-zero. Similarly, a split is triggered when the number of enemies goes back to zero.
